### PR TITLE
fix: remove stale CRA service worker causing blank page

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,19 @@
   </head>
   <body>
     <div id="app"></div>
+    <script>
+      // Belt-and-suspenders: drop any leftover service worker / caches from the
+      // previous Create React App site so the page never serves stale assets.
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker
+          .getRegistrations?.()
+          .then((regs) => regs.forEach((reg) => reg.unregister()))
+          .catch(() => {})
+        if (window.caches) {
+          caches.keys().then((keys) => keys.forEach((k) => caches.delete(k))).catch(() => {})
+        }
+      }
+    </script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,30 @@
+/*
+ * Self-destroying service worker.
+ *
+ * The previous Create React App site registered a service worker at this path
+ * that aggressively precached its bundle. After migrating to Vite, that stale
+ * worker keeps serving deleted assets to returning visitors and blanks the page.
+ *
+ * Browsers always revalidate the SW script, so they pick this up, activate it,
+ * and it unregisters itself + clears all caches + reloads open tabs onto the
+ * fresh site. Once gone, no SW is registered by the new app.
+ */
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      try {
+        const keys = await caches.keys()
+        await Promise.all(keys.map((key) => caches.delete(key)))
+      } catch (err) {
+        /* ignore */
+      }
+      await self.registration.unregister()
+      const clients = await self.clients.matchAll({ type: 'window' })
+      clients.forEach((client) => client.navigate(client.url))
+    })(),
+  )
+})


### PR DESCRIPTION
## Problem
`https://hendri1.github.io/` rendered **blank** for returning visitors. The previous Create React App site had registered a service worker that kept serving its old (now-deleted) precached bundle, so the new Vite app never mounted.

## Fix
- **`public/service-worker.js`** — a self-destroying worker served at the old SW path. Browsers always revalidate the SW script, pick this up, and it unregisters itself, clears all caches, and reloads open tabs onto the fresh build.
- **`index.html`** — inline guard that unregisters any leftover service worker and clears caches on load (covers direct loads).

The Vite build itself was already correct (root-relative `/assets/*`, `#app` mount) — this only neutralizes the stale browser-side worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT)_