### PR TITLE
feat: tech/sci-fi redesign — HUD palette, starfield, parallax & decode FX

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,7 @@ onUnmounted(() => destroySmoothScroll())
 
 <template>
   <div class="fx-grid" aria-hidden="true" />
+  <div class="fx-scanlines" aria-hidden="true" />
   <div class="fx-grain" aria-hidden="true" />
   <ScrollProgress />
   <CustomCursor />

--- a/src/directives.d.ts
+++ b/src/directives.d.ts
@@ -1,12 +1,14 @@
 import type { vReveal } from './presentation/directives/reveal'
 import type { vMagnetic } from './presentation/directives/magnetic'
 import type { vTilt } from './presentation/directives/tilt'
+import type { vParallax } from './presentation/directives/parallax'
 
 declare module 'vue' {
   interface GlobalDirectives {
     vReveal: typeof vReveal
     vMagnetic: typeof vMagnetic
     vTilt: typeof vTilt
+    vParallax: typeof vParallax
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import App from './App.vue'
 import { vReveal } from './presentation/directives/reveal'
 import { vMagnetic } from './presentation/directives/magnetic'
 import { vTilt } from './presentation/directives/tilt'
+import { vParallax } from './presentation/directives/parallax'
 import '@fontsource-variable/geist'
 import '@fontsource-variable/geist-mono'
 import './style.css'
@@ -11,4 +12,5 @@ createApp(App)
   .directive('reveal', vReveal)
   .directive('magnetic', vMagnetic)
   .directive('tilt', vTilt)
+  .directive('parallax', vParallax)
   .mount('#app')

--- a/src/presentation/components/fx/ParticleField.vue
+++ b/src/presentation/components/fx/ParticleField.vue
@@ -5,15 +5,21 @@ const canvas = ref<HTMLCanvasElement | null>(null)
 let raf = 0
 let cleanup: (() => void) | null = null
 
-interface P {
+interface Star {
   x: number
   y: number
-  vx: number
-  vy: number
+  z: number // depth 0..1 (parallax + size)
   r: number
-  a: number
-  warm: boolean
+  tw: number // twinkle phase
+  c: number // colour index
 }
+
+// ice, cyan, magenta
+const COLORS = [
+  [210, 224, 245],
+  [45, 226, 230],
+  [255, 46, 151],
+]
 
 onMounted(() => {
   const el = canvas.value
@@ -25,12 +31,9 @@ onMounted(() => {
   const dpr = Math.min(window.devicePixelRatio || 1, 2)
   let w = 0
   let h = 0
-  let particles: P[] = []
-  const pointer = { x: -9999, y: -9999, active: false }
+  let stars: Star[] = []
+  const pointer = { x: 0, y: 0, active: false }
   let visible = true
-
-  const ACCENT = [255, 91, 35] // #FF5B23
-  const SOFT = [232, 176, 75] // #E8B04B
 
   const resize = () => {
     const rect = el.parentElement?.getBoundingClientRect()
@@ -42,74 +45,54 @@ onMounted(() => {
     el.style.height = `${h}px`
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
-    const count = Math.round(Math.min(140, Math.max(50, (w * h) / 14000)))
-    particles = Array.from({ length: count }, () => ({
-      x: Math.random() * w,
-      y: Math.random() * h,
-      vx: (Math.random() - 0.5) * 0.25,
-      vy: -0.15 - Math.random() * 0.4,
-      r: 0.6 + Math.random() * 1.8,
-      a: 0.15 + Math.random() * 0.5,
-      warm: Math.random() > 0.7,
-    }))
-  }
-
-  const drawStatic = () => {
-    ctx.clearRect(0, 0, w, h)
-    ctx.globalCompositeOperation = 'lighter'
-    for (const p of particles) {
-      const [r, g, b] = p.warm ? SOFT : ACCENT
-      ctx.fillStyle = `rgba(${r},${g},${b},${p.a})`
-      ctx.beginPath()
-      ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2)
-      ctx.fill()
-    }
-    ctx.globalCompositeOperation = 'source-over'
+    const count = Math.round(Math.min(180, Math.max(70, (w * h) / 11000)))
+    stars = Array.from({ length: count }, () => {
+      const z = Math.random()
+      return {
+        x: Math.random() * w,
+        y: Math.random() * h,
+        z,
+        r: 0.4 + z * 1.7,
+        tw: Math.random() * Math.PI * 2,
+        c: Math.random() > 0.9 ? (Math.random() > 0.5 ? 2 : 1) : 0,
+      }
+    })
   }
 
   let t = 0
-  const tick = () => {
-    raf = requestAnimationFrame(tick)
-    if (!visible) return
-    t += 0.004
+  const draw = (animate: boolean) => {
     ctx.clearRect(0, 0, w, h)
     ctx.globalCompositeOperation = 'lighter'
-
-    for (const p of particles) {
-      // gentle flow field
-      p.x += p.vx + Math.sin(p.y * 0.01 + t) * 0.18
-      p.y += p.vy
-
-      // cursor attraction (local light source)
-      if (pointer.active) {
-        const dx = pointer.x - p.x
-        const dy = pointer.y - p.y
-        const d2 = dx * dx + dy * dy
-        if (d2 < 26000) {
-          const f = (1 - d2 / 26000) * 0.04
-          p.x += dx * f
-          p.y += dy * f
+    const ox = pointer.active ? (pointer.x - w / 2) : 0
+    const oy = pointer.active ? (pointer.y - h / 2) : 0
+    for (const s of stars) {
+      if (animate) {
+        s.y += 0.04 + s.z * 0.12 // slow drift
+        if (s.y > h + 4) {
+          s.y = -4
+          s.x = Math.random() * w
         }
+        s.tw += 0.02 + s.z * 0.03
       }
-
-      // wrap
-      if (p.y < -10) {
-        p.y = h + 10
-        p.x = Math.random() * w
-      }
-      if (p.x < -10) p.x = w + 10
-      if (p.x > w + 10) p.x = -10
-
-      const near = pointer.active
-        ? Math.max(0, 1 - ((pointer.x - p.x) ** 2 + (pointer.y - p.y) ** 2) / 40000)
-        : 0
-      const [r, g, b] = p.warm ? SOFT : ACCENT
-      ctx.fillStyle = `rgba(${r},${g},${b},${Math.min(1, p.a + near * 0.5)})`
+      const twinkle = animate ? 0.55 + 0.45 * Math.sin(s.tw) : 0.8
+      // parallax: deeper stars shift less
+      const px = s.x + (ox * s.z * 0.02)
+      const py = s.y + (oy * s.z * 0.02)
+      const [r, g, b] = COLORS[s.c]
+      ctx.fillStyle = `rgba(${r},${g},${b},${(0.25 + s.z * 0.5) * twinkle})`
       ctx.beginPath()
-      ctx.arc(p.x, p.y, p.r + near * 1.5, 0, Math.PI * 2)
+      ctx.arc(px, py, s.r, 0, Math.PI * 2)
       ctx.fill()
     }
     ctx.globalCompositeOperation = 'source-over'
+  }
+
+  t = 0
+  const tick = () => {
+    raf = requestAnimationFrame(tick)
+    if (!visible) return
+    t += 1
+    draw(true)
   }
 
   const onMove = (e: MouseEvent) => {
@@ -118,13 +101,9 @@ onMounted(() => {
     pointer.y = e.clientY - rect.top
     pointer.active = true
   }
-  const onLeave = () => {
-    pointer.active = false
-  }
   const onVisibility = () => {
     visible = !document.hidden
   }
-
   const io = new IntersectionObserver(
     (entries) => {
       visible = entries[0]?.isIntersecting ?? true
@@ -135,21 +114,16 @@ onMounted(() => {
   resize()
   window.addEventListener('resize', resize)
   window.addEventListener('mousemove', onMove, { passive: true })
-  window.addEventListener('mouseout', onLeave)
   document.addEventListener('visibilitychange', onVisibility)
   io.observe(el)
 
-  if (reduce) {
-    drawStatic()
-  } else {
-    raf = requestAnimationFrame(tick)
-  }
+  if (reduce) draw(false)
+  else raf = requestAnimationFrame(tick)
 
   cleanup = () => {
     cancelAnimationFrame(raf)
     window.removeEventListener('resize', resize)
     window.removeEventListener('mousemove', onMove)
-    window.removeEventListener('mouseout', onLeave)
     document.removeEventListener('visibilitychange', onVisibility)
     io.disconnect()
   }

--- a/src/presentation/components/sections/HeroSection.vue
+++ b/src/presentation/components/sections/HeroSection.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import AppIcon from '../ui/AppIcon.vue'
 import SocialLinks from '../ui/SocialLinks.vue'
+import DecodeText from '../ui/DecodeText.vue'
 import ParticleField from '../fx/ParticleField.vue'
 import { usePortfolio } from '@/presentation/composables/usePortfolio'
 
@@ -10,7 +11,6 @@ const calendlyUrl = computed(
   () => profile.socials.find((s) => s.kind === 'calendly')?.url ?? '#contact',
 )
 
-// Live local time in Bandung / Jakarta.
 const clock = ref('')
 let timer: ReturnType<typeof setInterval> | undefined
 const fmt = new Intl.DateTimeFormat('en-GB', {
@@ -20,9 +20,7 @@ const fmt = new Intl.DateTimeFormat('en-GB', {
   hour12: false,
   timeZone: 'Asia/Jakarta',
 })
-const updateClock = () => {
-  clock.value = fmt.format(new Date())
-}
+const updateClock = () => (clock.value = fmt.format(new Date()))
 onMounted(() => {
   updateClock()
   timer = setInterval(updateClock, 1000)
@@ -36,33 +34,55 @@ onUnmounted(() => clearInterval(timer))
     data-testid="hero"
     class="relative flex min-h-screen flex-col justify-center overflow-hidden px-4 pt-24 pb-16 sm:px-8"
   >
-    <ParticleField />
-    <!-- vignette so the type stays legible over the field -->
+    <!-- depth layers (back → front) -->
+    <div class="pointer-events-none absolute inset-0 z-0 flex items-center justify-center" aria-hidden="true">
+      <span
+        v-parallax="-0.25"
+        class="font-mono font-bold tracking-tighter text-accent/5 select-none"
+        style="font-size: clamp(12rem, 34vw, 34rem); line-height: 1"
+        >HFH</span
+      >
+    </div>
+    <div class="absolute inset-0 z-[1]" aria-hidden="true">
+      <ParticleField />
+    </div>
     <div
-      class="pointer-events-none absolute inset-0 -z-0"
+      class="pointer-events-none absolute inset-0 z-[2]"
       aria-hidden="true"
       style="
         background:
-          radial-gradient(120% 80% at 50% 40%, transparent 40%, var(--color-bg) 92%),
-          linear-gradient(to bottom, transparent 60%, var(--color-bg));
+          radial-gradient(120% 80% at 50% 30%, transparent 35%, var(--color-bg) 92%),
+          linear-gradient(to bottom, transparent 55%, var(--color-bg));
       "
     />
+    <!-- sweeping scan line -->
+    <div class="scan pointer-events-none absolute inset-x-0 top-0 z-[2]" aria-hidden="true" />
+
+    <!-- HUD telemetry corners -->
+    <div
+      class="pointer-events-none absolute inset-x-4 top-20 flex justify-between font-mono text-[0.65rem] tracking-widest text-muted uppercase sm:inset-x-8"
+      aria-hidden="true"
+    >
+      <span>SYS // PORTFOLIO.v1</span>
+      <span class="text-accent">◢ ONLINE</span>
+    </div>
 
     <div class="relative z-10 mx-auto w-full max-w-6xl">
       <div class="flex items-start justify-between gap-4">
         <p class="kicker flex items-center gap-2">
           <span class="inline-block h-px w-8 bg-accent" aria-hidden="true" />
-          01 / Senior Frontend Engineer · Mekari
+          <DecodeText text="01 / Senior Frontend Engineer · Mekari" />
         </p>
         <div class="hidden text-right sm:block">
-          <p class="font-mono text-xs text-muted">BANDUNG, ID</p>
+          <p class="font-mono text-xs text-muted">LAT -6.91 · LON 107.61</p>
           <p class="font-mono text-xs text-accent" data-testid="local-clock">{{ clock }} WIB</p>
         </div>
       </div>
 
       <h1
         data-testid="hero-name"
-        class="mt-8 font-semibold tracking-tight uppercase"
+        class="glitch glow mt-8 font-semibold tracking-tight uppercase"
+        :data-text="profile.name"
         style="font-size: clamp(3rem, 11vw, 9rem); line-height: 0.9; letter-spacing: -0.03em"
       >
         {{ profile.name }}
@@ -74,8 +94,8 @@ onUnmounted(() => clearInterval(timer))
         class="mt-6 inline-flex items-center gap-2 font-mono text-xs tracking-wide text-muted uppercase"
       >
         <span class="relative flex size-2">
-          <span class="absolute inline-flex size-full animate-ping rounded-full bg-accent opacity-70" />
-          <span class="relative inline-flex size-2 rounded-full bg-accent" />
+          <span class="absolute inline-flex size-full animate-ping rounded-full bg-accent3 opacity-70" />
+          <span class="relative inline-flex size-2 rounded-full bg-accent3" />
         </span>
         Open to senior frontend roles
       </p>
@@ -92,7 +112,7 @@ onUnmounted(() => clearInterval(timer))
           rel="noopener noreferrer"
           data-testid="hero-cta-call"
           data-cursor
-          class="inline-flex items-center gap-2 rounded-full bg-accent px-6 py-3 text-sm font-semibold text-[#0c0a08] transition-colors hover:bg-accent-soft"
+          class="inline-flex items-center gap-2 rounded-md bg-accent px-6 py-3 text-sm font-semibold text-[#06070d] transition-colors hover:bg-accent-soft"
         >
           <AppIcon name="calendar" :size="18" />
           Book a call
@@ -102,7 +122,7 @@ onUnmounted(() => clearInterval(timer))
           href="#work"
           data-testid="hero-cta-work"
           data-cursor
-          class="inline-flex items-center gap-2 rounded-full border border-line px-6 py-3 text-sm font-semibold text-fg transition-colors hover:border-accent"
+          class="inline-flex items-center gap-2 rounded-md border border-line px-6 py-3 text-sm font-semibold text-fg transition-colors hover:border-accent"
         >
           View work
           <AppIcon name="arrow-down" :size="16" />
@@ -110,12 +130,11 @@ onUnmounted(() => clearInterval(timer))
         <SocialLinks class="ml-1" :socials="profile.socials" />
       </div>
 
-      <!-- stats as a mono datasheet row -->
       <dl
         data-testid="hero-stats"
-        class="mt-14 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-line bg-line lg:grid-cols-4"
+        class="mt-14 grid grid-cols-2 gap-px overflow-hidden rounded-md border border-line bg-line lg:grid-cols-4"
       >
-        <div v-for="stat in profile.highlights" :key="stat.label" class="bg-bg p-5">
+        <div v-for="stat in profile.highlights" :key="stat.label" class="hud bg-bg p-5">
           <dt class="text-2xl font-semibold text-fg sm:text-3xl">{{ stat.value }}</dt>
           <dd class="mt-1 font-mono text-xs tracking-wide text-muted uppercase">{{ stat.label }}</dd>
         </div>
@@ -126,8 +145,43 @@ onUnmounted(() => clearInterval(timer))
       href="#about"
       class="absolute bottom-6 left-1/2 z-10 -translate-x-1/2 font-mono text-[0.65rem] tracking-[0.3em] text-muted uppercase"
       aria-label="Scroll down"
+      >↓ scroll</a
     >
-      ↓ scroll
-    </a>
   </section>
 </template>
+
+<style scoped>
+.scan {
+  top: 0;
+  height: 2px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in oklab, var(--color-accent) 70%, transparent),
+    transparent
+  );
+  animation: scan 7s linear infinite;
+}
+@keyframes scan {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(100vh);
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .scan {
+    animation: none;
+    display: none;
+  }
+}
+</style>

--- a/src/presentation/components/ui/DecodeText.vue
+++ b/src/presentation/components/ui/DecodeText.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+
+const props = withDefaults(defineProps<{ text: string; duration?: number }>(), {
+  duration: 900,
+})
+
+const GLYPHS = '!<>-_\\/[]{}—=+*^?#01010'
+const display = ref(props.text)
+const root = ref<HTMLElement | null>(null)
+let raf = 0
+let io: IntersectionObserver | null = null
+
+function scramble() {
+  const final = props.text
+  const start = performance.now ? performance.now() : 0
+  const tick = (now: number) => {
+    const elapsed = (now || 0) - start
+    const progress = Math.min(1, elapsed / props.duration)
+    const revealed = Math.floor(progress * final.length)
+    let out = ''
+    for (let i = 0; i < final.length; i++) {
+      if (i < revealed || final[i] === ' ') out += final[i]
+      else out += GLYPHS[Math.floor(Math.random() * GLYPHS.length)]
+    }
+    display.value = out
+    if (progress < 1) raf = requestAnimationFrame(tick)
+    else display.value = final
+  }
+  raf = requestAnimationFrame(tick)
+}
+
+onMounted(() => {
+  if (typeof window === 'undefined') return
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    display.value = props.text
+    return
+  }
+  io = new IntersectionObserver(
+    (entries) => {
+      if (entries[0]?.isIntersecting) {
+        scramble()
+        io?.disconnect()
+      }
+    },
+    { threshold: 0.4 },
+  )
+  if (root.value) io.observe(root.value)
+})
+
+onUnmounted(() => {
+  cancelAnimationFrame(raf)
+  io?.disconnect()
+})
+</script>
+
+<template>
+  <span ref="root" :aria-label="text"><span aria-hidden="true">{{ display }}</span></span>
+</template>

--- a/src/presentation/components/ui/SectionHeading.vue
+++ b/src/presentation/components/ui/SectionHeading.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import DecodeText from './DecodeText.vue'
 defineProps<{ eyebrow: string; title: string; subtitle?: string }>()
 </script>
 
@@ -12,7 +13,7 @@ defineProps<{ eyebrow: string; title: string; subtitle?: string }>()
       class="mt-4 font-semibold tracking-tight text-fg"
       style="font-size: clamp(2rem, 5vw, 3.5rem); line-height: 1.05; letter-spacing: -0.02em"
     >
-      {{ title }}
+      <DecodeText :text="title" />
     </h2>
     <p v-if="subtitle" class="mt-4 text-base text-muted">{{ subtitle }}</p>
   </header>

--- a/src/presentation/directives/parallax.ts
+++ b/src/presentation/directives/parallax.ts
@@ -1,0 +1,38 @@
+import type { Directive } from 'vue'
+import { gsap } from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+
+gsap.registerPlugin(ScrollTrigger)
+
+/**
+ * v-parallax — scrubbed vertical parallax tied to scroll. Binding value is the
+ * travel as a fraction of the element height (default 0.2; negative = opposite
+ * direction). Disabled under prefers-reduced-motion.
+ */
+const tweens = new WeakMap<HTMLElement, gsap.core.Tween>()
+
+export const vParallax: Directive<HTMLElement, number | undefined> = {
+  mounted(el, binding) {
+    if (typeof window === 'undefined') return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    const amount = binding.value ?? 0.2
+    const tween = gsap.to(el, {
+      yPercent: -amount * 100,
+      ease: 'none',
+      scrollTrigger: {
+        trigger: el,
+        start: 'top bottom',
+        end: 'bottom top',
+        scrub: true,
+      },
+    })
+    tweens.set(el, tween)
+  },
+  unmounted(el) {
+    const tween = tweens.get(el)
+    tween?.scrollTrigger?.kill()
+    tween?.kill()
+    tweens.delete(el)
+  },
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,46 +1,51 @@
 @import 'tailwindcss';
 
-/* Class-based dark mode (toggled on <html>) — this design is dark-first. */
+/* Class-based dark mode (toggled on <html>) — sci-fi is dark-first. */
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
   --font-sans: 'Geist Variable', ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-mono: 'Geist Mono Variable', ui-monospace, 'JetBrains Mono', 'SFMono-Regular', monospace;
 
-  /* Semantic tokens resolved from CSS variables that flip with the theme. */
   --color-bg: var(--bg);
   --color-surface: var(--surface);
   --color-surface2: var(--surface-2);
   --color-line: var(--line);
   --color-fg: var(--fg);
   --color-muted: var(--muted);
-  --color-accent: var(--accent);
-  --color-accent-soft: var(--accent-soft);
+  --color-accent: var(--accent); /* cyan — primary HUD */
+  --color-accent-soft: var(--accent-soft); /* soft cyan */
+  --color-accent2: var(--accent-2); /* magenta — secondary */
+  --color-accent3: var(--accent-3); /* lime — status/online */
 }
 
 @layer base {
-  /* Light — warm parchment (default; still no slate/neon). */
+  /* Light — "blueprint": pale ice + ink + cyan. */
   :root {
-    --bg: #f4f2ed;
-    --surface: #fbfaf6;
-    --surface-2: #efebe2;
-    --line: #e0dacd;
-    --fg: #1a1611;
-    --muted: #6b6457;
-    --accent: #d84f1c;
-    --accent-soft: #b97e22;
+    --bg: #eef2fb;
+    --surface: #ffffff;
+    --surface-2: #e6ecfa;
+    --line: #cdd8ee;
+    --fg: #0b1020;
+    --muted: #586079;
+    --accent: #0892a5;
+    --accent-soft: #1bb6c9;
+    --accent-2: #d6248a;
+    --accent-3: #4f9e1f;
   }
 
-  /* Dark — "terminal noir": warm carbon + amber signal (default via <html class="dark">). */
+  /* Dark — "deep space" HUD. (default via <html class="dark">) */
   .dark {
-    --bg: #0c0a08;
-    --surface: #141009;
-    --surface-2: #1e1810;
-    --line: #2a2118;
-    --fg: #f2ebdd;
-    --muted: #9a9183;
-    --accent: #ff5b23;
-    --accent-soft: #e8b04b;
+    --bg: #06070d;
+    --surface: #0c0f1a;
+    --surface-2: #121726;
+    --line: #1e2740;
+    --fg: #dce6f5;
+    --muted: #6e7a93;
+    --accent: #2de2e6;
+    --accent-soft: #7af5f7;
+    --accent-2: #ff2e97;
+    --accent-3: #b6ff3c;
   }
 
   html {
@@ -55,40 +60,37 @@
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
-    font-feature-settings: 'ss01', 'cv01';
+    overflow-x: hidden;
   }
 
   ::selection {
-    background-color: color-mix(in oklab, var(--color-accent) 40%, transparent);
+    background-color: color-mix(in oklab, var(--color-accent) 45%, transparent);
     color: var(--color-fg);
   }
 
   *:focus-visible {
     outline: 2px solid var(--color-accent);
     outline-offset: 3px;
-    border-radius: 2px;
   }
 
-  /* Tabular figures for all the mono metadata. */
   .font-mono {
     font-variant-numeric: tabular-nums;
   }
 }
 
 @layer components {
-  /* Mono micro-label: "— 02 / SELECTED WORK" */
   .kicker {
     font-family: var(--font-mono);
-    font-size: 0.75rem;
-    letter-spacing: 0.18em;
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--color-muted);
+    color: var(--color-accent);
   }
 
-  /* Scroll reveal (IntersectionObserver via v-reveal). */
+  /* Reveal (IntersectionObserver via v-reveal). */
   .reveal {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(22px);
     transition:
       opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
       transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
@@ -99,7 +101,6 @@
     transform: none;
   }
 
-  /* Animated underline for links. */
   .link-underline {
     background-image: linear-gradient(var(--color-accent), var(--color-accent));
     background-position: 0 100%;
@@ -111,7 +112,37 @@
     background-size: 100% 1.5px;
   }
 
-  /* Faint instrument grid + film grain overlays (fixed, non-interactive). */
+  /* HUD corner brackets on a container. */
+  .hud {
+    position: relative;
+  }
+  .hud::before,
+  .hud::after {
+    content: '';
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border: 1px solid color-mix(in oklab, var(--color-accent) 60%, transparent);
+    pointer-events: none;
+  }
+  .hud::before {
+    top: -1px;
+    left: -1px;
+    border-right: 0;
+    border-bottom: 0;
+  }
+  .hud::after {
+    right: -1px;
+    bottom: -1px;
+    border-left: 0;
+    border-top: 0;
+  }
+
+  .glow {
+    text-shadow: 0 0 18px color-mix(in oklab, var(--color-accent) 55%, transparent);
+  }
+
+  /* Global FX overlays. */
   .fx-grid {
     position: fixed;
     inset: 0;
@@ -120,21 +151,34 @@
     background-image:
       linear-gradient(to right, var(--color-line) 1px, transparent 1px),
       linear-gradient(to bottom, var(--color-line) 1px, transparent 1px);
-    background-size: clamp(60px, 8vw, 120px) clamp(60px, 8vw, 120px);
-    opacity: 0.25;
-    mask-image: radial-gradient(ellipse 100% 70% at 50% 0%, #000 30%, transparent 80%);
+    background-size: clamp(48px, 6vw, 96px) clamp(48px, 6vw, 96px);
+    opacity: 0.35;
+    mask-image: radial-gradient(ellipse 120% 80% at 50% 0%, #000 25%, transparent 75%);
+  }
+  .fx-scanlines {
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    opacity: 0.5;
+    background: repeating-linear-gradient(
+      to bottom,
+      transparent 0 2px,
+      color-mix(in oklab, var(--color-fg) 4%, transparent) 2px 3px
+    );
+    mix-blend-mode: overlay;
   }
   .fx-grain {
     position: fixed;
     inset: 0;
     z-index: 1;
     pointer-events: none;
-    opacity: 0.035;
+    opacity: 0.04;
     mix-blend-mode: overlay;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
   }
 
-  /* Custom cursor (desktop, pointer-fine only). */
+  /* Reticle cursor. */
   .cursor-dot,
   .cursor-ring {
     position: fixed;
@@ -142,28 +186,52 @@
     left: 0;
     z-index: 90;
     pointer-events: none;
-    border-radius: 9999px;
     translate: -50% -50%;
-    mix-blend-mode: difference;
   }
   .cursor-dot {
-    width: 6px;
-    height: 6px;
-    background: #fff;
+    width: 5px;
+    height: 5px;
+    border-radius: 9999px;
+    background: var(--color-accent);
+    box-shadow: 0 0 10px var(--color-accent);
   }
   .cursor-ring {
-    width: 34px;
-    height: 34px;
-    border: 1px solid #fff;
+    width: 30px;
+    height: 30px;
+    border: 1px solid color-mix(in oklab, var(--color-accent) 70%, transparent);
+    border-radius: 9999px;
     transition:
       width 0.25s ease,
       height 0.25s ease,
+      border-radius 0.25s ease,
       background-color 0.25s ease;
   }
+  /* crosshair ticks */
+  .cursor-ring::before,
+  .cursor-ring::after {
+    content: '';
+    position: absolute;
+    background: color-mix(in oklab, var(--color-accent) 70%, transparent);
+  }
+  .cursor-ring::before {
+    top: 50%;
+    left: -6px;
+    right: -6px;
+    height: 1px;
+    transform: translateY(-50%);
+  }
+  .cursor-ring::after {
+    left: 50%;
+    top: -6px;
+    bottom: -6px;
+    width: 1px;
+    transform: translateX(-50%);
+  }
   .cursor-ring.is-hover {
-    width: 56px;
-    height: 56px;
-    background: rgba(255, 255, 255, 0.08);
+    width: 54px;
+    height: 54px;
+    border-radius: 6px;
+    background: color-mix(in oklab, var(--color-accent) 8%, transparent);
   }
   @media (hover: none), (pointer: coarse) {
     .cursor-dot,
@@ -171,7 +239,6 @@
       display: none;
     }
   }
-  /* Hide the native cursor only once the custom one is mounted (fine pointers). */
   @media (hover: hover) and (pointer: fine) {
     .has-custom-cursor,
     .has-custom-cursor a,
@@ -179,6 +246,38 @@
       cursor: none;
     }
   }
+}
+
+/* Hero name glitch on hover (RGB split). */
+@keyframes glitch {
+  0%, 100% { transform: translate(0); }
+  20% { transform: translate(-1px, 1px); }
+  40% { transform: translate(-1px, -1px); }
+  60% { transform: translate(1px, 1px); }
+  80% { transform: translate(1px, -1px); }
+}
+.glitch {
+  position: relative;
+}
+.glitch:hover {
+  animation: glitch 0.3s steps(2) infinite;
+}
+.glitch:hover::before,
+.glitch:hover::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.glitch:hover::before {
+  color: var(--color-accent);
+  transform: translate(-2px, 0);
+  mix-blend-mode: screen;
+}
+.glitch:hover::after {
+  color: var(--color-accent2);
+  transform: translate(2px, 0);
+  mix-blend-mode: screen;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -190,7 +289,11 @@
     transform: none;
     transition: none;
   }
-  .fx-grain {
+  .fx-grain,
+  .fx-scanlines {
     display: none;
+  }
+  .glitch:hover {
+    animation: none;
   }
 }


### PR DESCRIPTION
## Why
The amber "Terminal Noir" look read as a Claude/Anthropic theme. This re-skins to a **deep-space sci-fi HUD** aesthetic with richer, scroll-driven interaction.

## Changes
- **Palette:** deep-space dark + **cyan/magenta** dual accent + **lime** status (light mode = "blueprint": ice/ink/cyan). Recolor flows through CSS tokens, so components barely changed.
- **FX / motion:**
  - Twinkling **starfield** with cursor parallax
  - Scrubbed **`v-parallax`** depth layers (GSAP ScrollTrigger) — incl. a faint "HFH" monogram behind the hero
  - **Decode/scramble** section + kicker text
  - **RGB-split glitch** on the hero name (hover)
  - Sweeping **scan line**, **scanline + grid + grain** overlays
  - **Reticle/crosshair** cursor; HUD telemetry readouts (`SYS // PORTFOLIO.V1`, `LAT/LON`, `◢ ONLINE`)
- **A11y/perf:** every effect gated behind `prefers-reduced-motion`; disabled for coarse pointers; all `data-testid`s preserved.

## Tests
19 Vitest unit + 13 Playwright E2E green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT)_