### PR TITLE
feat: parallax-driven layout — sticky-stacking work + depth watermarks

### DIFF
--- a/src/components/fx/ParallaxText.vue
+++ b/src/components/fx/ParallaxText.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+withDefaults(defineProps<{ text: string; amount?: number; position?: string }>(), {
+  amount: 0.5,
+  position: 'top-0 -right-6',
+})
+</script>
+
+<template>
+  <span
+    v-parallax="amount"
+    aria-hidden="true"
+    class="pointer-events-none absolute z-0 font-mono font-bold tracking-tighter uppercase select-none"
+    :class="position"
+    style="
+      font-size: clamp(5rem, 16vw, 15rem);
+      line-height: 0.85;
+      color: transparent;
+      -webkit-text-stroke: 1px color-mix(in oklab, var(--color-accent) 22%, transparent);
+    "
+    >{{ text }}</span
+  >
+</template>

--- a/src/components/sections/AboutSection.vue
+++ b/src/components/sections/AboutSection.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import SectionHeading from '../ui/SectionHeading.vue'
 import TagBadge from '../ui/TagBadge.vue'
+import ParallaxText from '../fx/ParallaxText.vue'
 import { usePortfolio } from '@/composables/usePortfolio'
 
 const { profile } = usePortfolio()
 </script>
 
 <template>
-  <section id="about" data-testid="about" class="mx-auto max-w-6xl px-4 py-24 sm:px-8">
+  <section id="about" data-testid="about" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
+    <ParallaxText text="ABOUT" position="-top-10 -left-4" :amount="0.55" />
     <SectionHeading eyebrow="02 / About" title="Engineer, architect, mentor" />
 
     <div class="grid gap-px overflow-hidden rounded-2xl border border-line bg-line lg:grid-cols-3">

--- a/src/components/sections/ContactSection.vue
+++ b/src/components/sections/ContactSection.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import SectionHeading from '../ui/SectionHeading.vue'
 import AppIcon from '../ui/AppIcon.vue'
+import ParallaxText from '../fx/ParallaxText.vue'
 import { usePortfolio } from '@/composables/usePortfolio'
 
 const { profile } = usePortfolio()
@@ -27,7 +28,8 @@ const calendlyEmbedUrl = computed(() => {
 </script>
 
 <template>
-  <section id="contact" data-testid="contact" class="mx-auto max-w-6xl px-4 py-24 sm:px-8">
+  <section id="contact" data-testid="contact" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
+    <ParallaxText text="CONTACT" position="-top-12 right-0" :amount="0.6" />
     <SectionHeading
       eyebrow="06 / Contact"
       title="Let's build something"

--- a/src/components/sections/ExperienceSection.vue
+++ b/src/components/sections/ExperienceSection.vue
@@ -2,13 +2,15 @@
 import SectionHeading from '../ui/SectionHeading.vue'
 import TagBadge from '../ui/TagBadge.vue'
 import AppIcon from '../ui/AppIcon.vue'
+import ParallaxText from '../fx/ParallaxText.vue'
 import { usePortfolio } from '@/composables/usePortfolio'
 
 const { experiences } = usePortfolio()
 </script>
 
 <template>
-  <section id="experience" data-testid="experience" class="mx-auto max-w-6xl px-4 py-24 sm:px-8">
+  <section id="experience" data-testid="experience" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
+    <ParallaxText text="CAREER" position="-top-12 right-0" :amount="0.6" />
     <SectionHeading
       eyebrow="03 / Experience"
       title="A decade of shipping frontend"

--- a/src/components/sections/ProjectsSection.vue
+++ b/src/components/sections/ProjectsSection.vue
@@ -1,65 +1,115 @@
 <script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import { gsap } from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
 import SectionHeading from '../ui/SectionHeading.vue'
 import TagBadge from '../ui/TagBadge.vue'
 import AppIcon from '../ui/AppIcon.vue'
+import ParallaxText from '../fx/ParallaxText.vue'
 import { usePortfolio } from '@/composables/usePortfolio'
+
+gsap.registerPlugin(ScrollTrigger)
 
 const { projects } = usePortfolio()
 const pad = (n: number) => String(n).padStart(2, '0')
+
+const grid = ref<HTMLElement | null>(null)
+let mm: ReturnType<typeof gsap.matchMedia> | null = null
+
+onMounted(() => {
+  mm = gsap.matchMedia()
+  // Deck scale-down only on desktop, non-touch, motion-allowed.
+  mm.add('(min-width: 768px) and (prefers-reduced-motion: no-preference)', () => {
+    const cards = grid.value
+      ? Array.from(grid.value.querySelectorAll<HTMLElement>('[data-stack-card]'))
+      : []
+    cards.forEach((card, i) => {
+      if (i === cards.length - 1) return
+      const inner = card.querySelector<HTMLElement>('[data-stack-inner]')
+      if (!inner) return
+      gsap.to(inner, {
+        scale: 1 - (cards.length - 1 - i) * 0.05,
+        ease: 'none',
+        scrollTrigger: {
+          trigger: cards[i + 1],
+          start: 'top bottom',
+          end: 'top top',
+          scrub: true,
+        },
+      })
+    })
+  })
+})
+
+onUnmounted(() => mm?.revert())
 </script>
 
 <template>
-  <section id="work" data-testid="work" class="mx-auto max-w-6xl px-4 py-24 sm:px-8">
+  <section id="work" data-testid="work" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
+    <ParallaxText text="WORK" position="-top-12 right-0" :amount="0.6" />
     <SectionHeading
       eyebrow="04 / Selected Work"
       title="Projects & case studies"
-      subtitle="Highlights from work at Mekari and beyond — architecture, design systems, and products."
+      subtitle="Scroll — each project stacks over the last, like windows opening in a console."
     />
 
-    <div class="grid gap-4 sm:gap-5 md:grid-cols-2" data-testid="projects-grid">
+    <div ref="grid" data-testid="projects-grid" class="relative">
       <article
         v-for="(project, index) in projects"
         :key="project.id"
-        v-reveal="index * 60"
-        v-tilt="5"
+        data-stack-card
         :data-testid="`project-${project.id}`"
         data-cursor
-        class="group relative flex flex-col rounded-2xl border border-line bg-surface/40 p-6 transition-colors hover:border-accent/50 sm:p-8"
+        class="sticky"
+        :style="{ top: `${9 + index * 2.5}vh`, zIndex: index + 1 }"
       >
-        <div class="flex items-start justify-between gap-3">
-          <span class="font-mono text-sm text-accent">({{ pad(index + 1) }})</span>
-          <ul class="flex flex-wrap justify-end gap-1.5">
-            <li v-for="tag in project.tags" :key="tag">
-              <TagBadge accent>{{ tag }}</TagBadge>
+        <div
+          data-stack-inner
+          class="hud mb-8 flex min-h-[56svh] flex-col rounded-2xl border border-line bg-surface p-6 shadow-[0_-10px_50px_-20px_rgba(0,0,0,0.7)] sm:p-9"
+          style="transform-origin: top center; will-change: transform"
+        >
+          <div class="flex items-start justify-between gap-3">
+            <span class="font-mono text-sm text-accent"
+              >({{ pad(index + 1) }} / {{ pad(projects.length) }})</span
+            >
+            <ul class="flex flex-wrap justify-end gap-1.5">
+              <li v-for="tag in project.tags" :key="tag">
+                <TagBadge accent>{{ tag }}</TagBadge>
+              </li>
+            </ul>
+          </div>
+
+          <p class="mt-6 kicker">{{ project.context }}</p>
+          <h3 class="mt-2 text-2xl font-semibold text-fg sm:text-3xl">{{ project.name }}</h3>
+          <p class="mt-2 text-base font-medium text-muted">{{ project.tagline }}</p>
+          <p class="mt-4 max-w-2xl flex-1 text-sm leading-relaxed text-fg/80 sm:text-base">
+            {{ project.description }}
+          </p>
+
+          <ul class="mt-6 flex flex-wrap gap-1.5">
+            <li v-for="tech in project.stack" :key="tech">
+              <TagBadge>{{ tech }}</TagBadge>
             </li>
           </ul>
-        </div>
 
-        <p class="mt-5 kicker">{{ project.context }}</p>
-        <h3 class="mt-2 text-xl font-semibold text-fg">{{ project.name }}</h3>
-        <p class="mt-1 text-sm font-medium text-muted">{{ project.tagline }}</p>
-        <p class="mt-3 flex-1 text-sm leading-relaxed text-fg/80">{{ project.description }}</p>
-
-        <ul class="mt-5 flex flex-wrap gap-1.5">
-          <li v-for="tech in project.stack" :key="tech">
-            <TagBadge>{{ tech }}</TagBadge>
-          </li>
-        </ul>
-
-        <div v-if="project.links.length" class="mt-5 flex flex-wrap gap-4 border-t border-line pt-4">
-          <a
-            v-for="link in project.links"
-            :key="link.url"
-            :href="link.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            :data-testid="`project-link-${project.id}`"
-            data-cursor
-            class="inline-flex items-center gap-1.5 font-mono text-sm text-accent transition-opacity hover:opacity-80"
+          <div
+            v-if="project.links.length"
+            class="mt-6 flex flex-wrap gap-4 border-t border-line pt-4"
           >
-            {{ link.label }}
-            <AppIcon name="external" :size="14" />
-          </a>
+            <a
+              v-for="link in project.links"
+              :key="link.url"
+              :href="link.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              :data-testid="`project-link-${project.id}`"
+              data-cursor
+              class="inline-flex items-center gap-1.5 font-mono text-sm text-accent transition-opacity hover:opacity-80"
+            >
+              {{ link.label }}
+              <AppIcon name="external" :size="14" />
+            </a>
+          </div>
         </div>
       </article>
     </div>

--- a/src/components/sections/SkillsSection.vue
+++ b/src/components/sections/SkillsSection.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import SectionHeading from '../ui/SectionHeading.vue'
+import ParallaxText from '../fx/ParallaxText.vue'
 import { usePortfolio } from '@/composables/usePortfolio'
 
 const { skillGroups, education } = usePortfolio()
 </script>
 
 <template>
-  <section id="skills" data-testid="skills" class="mx-auto max-w-6xl px-4 py-24 sm:px-8">
+  <section id="skills" data-testid="skills" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
+    <ParallaxText text="STACK" position="-top-10 -left-4" :amount="0.55" />
     <SectionHeading
       eyebrow="05 / Skills"
       title="Tools of the trade"

--- a/src/composables/useSmoothScroll.ts
+++ b/src/composables/useSmoothScroll.ts
@@ -5,6 +5,9 @@ import { ScrollTrigger } from 'gsap/ScrollTrigger'
 
 gsap.registerPlugin(ScrollTrigger)
 
+// Don't let the mobile address-bar show/hide trigger pin/parallax recalcs.
+ScrollTrigger.config({ ignoreMobileResize: true })
+
 /** Scroll velocity (px/frame-ish), consumed by the marquee for skew/speed. */
 export const scrollVelocity = ref(0)
 
@@ -16,7 +19,9 @@ export function initSmoothScroll(): void {
   if (lenis || typeof window === 'undefined') return
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
 
-  lenis = new Lenis({ duration: 1.1, smoothWheel: true })
+  // autoRaf:false — we drive Lenis from GSAP's single ticker so ScrollTrigger
+  // never reads a stale scroll value (avoids 1–2 frame parallax/pin lag).
+  lenis = new Lenis({ duration: 1.1, smoothWheel: true, autoRaf: false })
   lenis.on('scroll', (e: { velocity: number }) => {
     ScrollTrigger.update()
     scrollVelocity.value = e.velocity
@@ -25,6 +30,7 @@ export function initSmoothScroll(): void {
   tickerFn = (time: number) => lenis?.raf(time * 1000)
   gsap.ticker.add(tickerFn)
   gsap.ticker.lagSmoothing(0)
+  ScrollTrigger.refresh()
 }
 
 export function destroySmoothScroll(): void {

--- a/src/style.css
+++ b/src/style.css
@@ -60,7 +60,9 @@
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
-    overflow-x: hidden;
+    /* clip (not hidden) so parallax watermarks can bleed without creating a
+       scroll container that would break `position: sticky` stacking. */
+    overflow-x: clip;
   }
 
   ::selection {


### PR DESCRIPTION
## Why
The previous pass changed the *theme* but kept a flat vertical stack. This is a **layout** redesign into a layered, scroll-driven parallax experience — grounded in research on real parallax portfolios (Phantom.land, Stefan Vitasović, GSAP stacking-cards) and GSAP ScrollTrigger + Lenis implementation recipes.

## Changes
- **Work → sticky-stacking cards.** Each project pins at the top and the next scrolls up over it like console windows; covered cards scale down (`targetScale = 1 − (n−1−i)·0.05`) for a deck depth cue on desktop. Robust **CSS `position: sticky`** (no GSAP pin-spacers), scale gated via `gsap.matchMedia('(min-width:768px) and (prefers-reduced-motion: no-preference)')`.
- **Section depth watermarks.** Giant outlined words (`ABOUT / CAREER / WORK / STACK / CONTACT`) drift behind content at a different scroll rate via the `v-parallax` directive (`ParallaxText`).
- **Foundations from research:** Lenis `autoRaf:false` driven by `gsap.ticker` (no 1–2 frame lag), `ScrollTrigger.config({ ignoreMobileResize:true })`, `body { overflow-x: clip }` (watermarks bleed without breaking sticky), `svh` units.

## Guarantees
- All effects gated behind `prefers-reduced-motion` / desktop; degrade to static.
- All `data-testid`s preserved; **19 Vitest unit + 13 Playwright E2E green**; type-check + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT)_