### PR TITLE
feat: horizontal-scroll Work gallery (left↔right slide parallax)

### DIFF
--- a/src/components/sections/ProjectsSection.vue
+++ b/src/components/sections/ProjectsSection.vue
@@ -5,7 +5,6 @@ import { ScrollTrigger } from 'gsap/ScrollTrigger'
 import SectionHeading from '../ui/SectionHeading.vue'
 import TagBadge from '../ui/TagBadge.vue'
 import AppIcon from '../ui/AppIcon.vue'
-import ParallaxText from '../fx/ParallaxText.vue'
 import { usePortfolio } from '@/composables/usePortfolio'
 
 gsap.registerPlugin(ScrollTrigger)
@@ -13,31 +12,45 @@ gsap.registerPlugin(ScrollTrigger)
 const { projects } = usePortfolio()
 const pad = (n: number) => String(n).padStart(2, '0')
 
-const grid = ref<HTMLElement | null>(null)
+const root = ref<HTMLElement | null>(null)
+const pinWrap = ref<HTMLElement | null>(null)
+const track = ref<HTMLElement | null>(null)
 let mm: ReturnType<typeof gsap.matchMedia> | null = null
 
 onMounted(() => {
   mm = gsap.matchMedia()
-  // Deck scale-down only on desktop, non-touch, motion-allowed.
+  // Horizontal pinned scroll only on desktop with motion allowed.
   mm.add('(min-width: 768px) and (prefers-reduced-motion: no-preference)', () => {
-    const cards = grid.value
-      ? Array.from(grid.value.querySelectorAll<HTMLElement>('[data-stack-card]'))
-      : []
-    cards.forEach((card, i) => {
-      if (i === cards.length - 1) return
-      const inner = card.querySelector<HTMLElement>('[data-stack-inner]')
-      if (!inner) return
-      gsap.to(inner, {
-        scale: 1 - (cards.length - 1 - i) * 0.05,
-        ease: 'none',
-        scrollTrigger: {
-          trigger: cards[i + 1],
-          start: 'top bottom',
-          end: 'top top',
-          scrub: true,
-        },
-      })
+    const sectionEl = root.value
+    const pin = pinWrap.value
+    const tr = track.value
+    if (!sectionEl || !pin || !tr) return
+
+    sectionEl.classList.add('is-horizontal')
+    const distance = () => Math.max(0, tr.scrollWidth - window.innerWidth)
+
+    const tween = gsap.to(tr, {
+      x: () => -distance(),
+      ease: 'none',
+      scrollTrigger: {
+        trigger: pin,
+        start: 'top top',
+        end: () => `+=${distance()}`,
+        pin: true,
+        scrub: 1,
+        anticipatePin: 1,
+        invalidateOnRefresh: true,
+      },
     })
+
+    ScrollTrigger.refresh()
+
+    return () => {
+      tween.scrollTrigger?.kill()
+      tween.kill()
+      sectionEl.classList.remove('is-horizontal')
+      gsap.set(tr, { clearProps: 'transform' })
+    }
   })
 })
 
@@ -45,33 +58,26 @@ onUnmounted(() => mm?.revert())
 </script>
 
 <template>
-  <section id="work" data-testid="work" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
-    <ParallaxText text="WORK" position="-top-12 right-0" :amount="0.6" />
-    <SectionHeading
-      eyebrow="04 / Selected Work"
-      title="Projects & case studies"
-      subtitle="Scroll — each project stacks over the last, like windows opening in a console."
-    />
+  <section id="work" ref="root" data-testid="work" class="relative py-24">
+    <div class="mx-auto max-w-6xl px-4 sm:px-8">
+      <SectionHeading
+        eyebrow="04 / Selected Work"
+        title="Projects & case studies"
+        subtitle="Scroll — the deck slides sideways through each project."
+      />
+    </div>
 
-    <div ref="grid" data-testid="projects-grid" class="relative">
-      <article
-        v-for="(project, index) in projects"
-        :key="project.id"
-        data-stack-card
-        :data-testid="`project-${project.id}`"
-        data-cursor
-        class="sticky"
-        :style="{ top: `${9 + index * 2.5}vh`, zIndex: index + 1 }"
-      >
-        <div
-          data-stack-inner
-          class="hud mb-8 flex min-h-[56svh] flex-col rounded-2xl border border-line bg-surface p-6 shadow-[0_-10px_50px_-20px_rgba(0,0,0,0.7)] sm:p-9"
-          style="transform-origin: top center; will-change: transform"
+    <div ref="pinWrap" class="work-pin">
+      <div ref="track" data-testid="projects-grid" class="work-track">
+        <article
+          v-for="(project, index) in projects"
+          :key="project.id"
+          :data-testid="`project-${project.id}`"
+          data-cursor
+          class="work-panel hud flex flex-col overflow-y-auto rounded-2xl border border-line bg-surface p-6 sm:p-9"
         >
           <div class="flex items-start justify-between gap-3">
-            <span class="font-mono text-sm text-accent"
-              >({{ pad(index + 1) }} / {{ pad(projects.length) }})</span
-            >
+            <span class="font-mono text-lg text-accent">{{ pad(index + 1) }}<span class="text-muted">/{{ pad(projects.length) }}</span></span>
             <ul class="flex flex-wrap justify-end gap-1.5">
               <li v-for="tag in project.tags" :key="tag">
                 <TagBadge accent>{{ tag }}</TagBadge>
@@ -82,7 +88,7 @@ onUnmounted(() => mm?.revert())
           <p class="mt-6 kicker">{{ project.context }}</p>
           <h3 class="mt-2 text-2xl font-semibold text-fg sm:text-3xl">{{ project.name }}</h3>
           <p class="mt-2 text-base font-medium text-muted">{{ project.tagline }}</p>
-          <p class="mt-4 max-w-2xl flex-1 text-sm leading-relaxed text-fg/80 sm:text-base">
+          <p class="mt-4 max-w-xl flex-1 text-sm leading-relaxed text-fg/80 sm:text-base">
             {{ project.description }}
           </p>
 
@@ -110,8 +116,55 @@ onUnmounted(() => mm?.revert())
               <AppIcon name="external" :size="14" />
             </a>
           </div>
-        </div>
-      </article>
+        </article>
+      </div>
     </div>
+
+    <p
+      class="mx-auto mt-8 hidden max-w-6xl px-4 font-mono text-xs tracking-widest text-muted uppercase sm:px-8 md:block"
+    >
+      ◢ scroll to traverse →
+    </p>
   </section>
 </template>
+
+<style scoped>
+/* Default (mobile / reduced-motion / no-JS): clean vertical stack. */
+.work-track {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-inline: auto;
+  max-width: 72rem;
+  padding-inline: 1rem;
+}
+.work-panel {
+  width: 100%;
+}
+
+/* Desktop horizontal mode, enabled via JS class once pinned. */
+.is-horizontal .work-pin {
+  height: 100svh;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+.is-horizontal .work-track {
+  flex-direction: row;
+  gap: 1.75rem;
+  max-width: none;
+  height: 74vh;
+  padding-inline: max(1rem, calc((100vw - 72rem) / 2));
+}
+.is-horizontal .work-panel {
+  flex: 0 0 auto;
+  width: min(72vw, 52rem);
+  height: 100%;
+}
+
+@media (min-width: 640px) {
+  .work-track {
+    padding-inline: 2rem;
+  }
+}
+</style>


### PR DESCRIPTION
## What
Adds the **horizontal "slide left↔right" scroll** (the Dribbble-style parallax you asked for) to the **Work** section: the section pins and the 4 project panels translate sideways as you scroll down.

- GSAP ScrollTrigger `pin` + scrubbed `x` translate of the panel track; `invalidateOnRefresh` recomputes travel on resize.
- **Desktop + motion-on only** (`gsap.matchMedia`). Panels are full-height cards that slide horizontally.
- **Mobile / reduced-motion / no-JS:** clean **vertical stack** fallback (CSS default; horizontal mode is enabled by a JS-added class).

## Guarantees
- All `data-testid`s preserved (`projects-grid` + 4 `project-*` articles).
- **19 unit + 13 E2E green**; type-check + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT)_