### PR TITLE
feat: reframe as an intuitive business profile (not just a CV)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,9 +3,12 @@ import { onMounted, onUnmounted } from 'vue'
 import AppHeader from '@/components/layout/AppHeader.vue'
 import AppFooter from '@/components/layout/AppFooter.vue'
 import HeroSection from '@/components/sections/HeroSection.vue'
+import TrustedBy from '@/components/sections/TrustedBy.vue'
+import ServicesSection from '@/components/sections/ServicesSection.vue'
 import AboutSection from '@/components/sections/AboutSection.vue'
 import ExperienceSection from '@/components/sections/ExperienceSection.vue'
 import ProjectsSection from '@/components/sections/ProjectsSection.vue'
+import ProcessSection from '@/components/sections/ProcessSection.vue'
 import SkillsSection from '@/components/sections/SkillsSection.vue'
 import ContactSection from '@/components/sections/ContactSection.vue'
 import MarqueeStrip from '@/components/fx/MarqueeStrip.vue'
@@ -35,10 +38,13 @@ onUnmounted(() => destroySmoothScroll())
 
   <main data-testid="app-main" class="relative z-10">
     <HeroSection />
-    <MarqueeStrip />
-    <AboutSection />
-    <ExperienceSection />
+    <TrustedBy />
+    <ServicesSection />
     <ProjectsSection />
+    <MarqueeStrip />
+    <ProcessSection />
+    <ExperienceSection />
+    <AboutSection />
     <SkillsSection />
     <ContactSection />
   </main>

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -11,10 +11,10 @@ const calendlyUrl = computed(
 )
 
 const links = [
-  { label: 'About', href: '#about', id: 'about' },
-  { label: 'Experience', href: '#experience', id: 'experience' },
+  { label: 'Services', href: '#services', id: 'services' },
   { label: 'Work', href: '#work', id: 'work' },
-  { label: 'Skills', href: '#skills', id: 'skills' },
+  { label: 'Process', href: '#process', id: 'process' },
+  { label: 'Experience', href: '#experience', id: 'experience' },
   { label: 'Contact', href: '#contact', id: 'contact' },
 ]
 

--- a/src/components/sections/AboutSection.vue
+++ b/src/components/sections/AboutSection.vue
@@ -10,7 +10,7 @@ const { profile } = usePortfolio()
 <template>
   <section id="about" data-testid="about" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
     <ParallaxText text="ABOUT" position="-top-10 -left-4" :amount="0.55" />
-    <SectionHeading eyebrow="02 / About" title="Engineer, architect, mentor" />
+    <SectionHeading eyebrow="05 / About" title="Engineer, architect, mentor" />
 
     <div class="grid gap-px overflow-hidden rounded-2xl border border-line bg-line lg:grid-cols-3">
       <div class="bg-bg p-7 lg:col-span-2 lg:p-9">

--- a/src/components/sections/ContactSection.vue
+++ b/src/components/sections/ContactSection.vue
@@ -49,9 +49,9 @@ async function copyEmail() {
   <section id="contact" data-testid="contact" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
     <ParallaxText text="CONTACT" position="-top-12 right-0" :amount="0.6" />
     <SectionHeading
-      eyebrow="06 / Contact"
-      title="Let's build something"
-      subtitle="Book a slot that suits you, or reach out directly — I usually reply within a day."
+      eyebrow="07 / Contact"
+      title="Let's work together"
+      subtitle="Have a frontend challenge or a team to scale? Book a slot that suits you, or reach out directly — I usually reply within a day."
     />
 
     <!-- oversized email statement + copy affordance -->

--- a/src/components/sections/ExperienceSection.vue
+++ b/src/components/sections/ExperienceSection.vue
@@ -12,7 +12,7 @@ const { experiences } = usePortfolio()
   <section id="experience" data-testid="experience" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
     <ParallaxText text="CAREER" position="-top-12 right-0" :amount="0.6" />
     <SectionHeading
-      eyebrow="03 / Experience"
+      eyebrow="04 / Track record"
       title="A decade of shipping frontend"
       subtitle="From hospital systems and analytics dashboards to micro-frontends and design systems at scale."
     />

--- a/src/components/sections/HeroSection.vue
+++ b/src/components/sections/HeroSection.vue
@@ -103,7 +103,7 @@ onUnmounted(() => {
       class="pointer-events-none absolute inset-x-4 top-20 flex justify-between font-mono text-[0.65rem] tracking-widest text-muted uppercase sm:inset-x-8"
       aria-hidden="true"
     >
-      <span data-boot-hud>SYS // PORTFOLIO.v1</span>
+      <span data-boot-hud>FRONTEND ENGINEERING · CONSULTING</span>
       <span
         data-boot-hud
         data-testid="hero-status"
@@ -117,39 +117,47 @@ onUnmounted(() => {
       <div class="flex items-start justify-between gap-4">
         <p data-boot="kicker" class="kicker flex items-center gap-2">
           <span class="inline-block h-px w-8 bg-accent" aria-hidden="true" />
-          <DecodeText text="01 / Senior Frontend Engineer · Mekari" />
+          <DecodeText text="Senior Frontend Engineer · 10+ years" />
         </p>
         <div class="hidden text-right sm:block">
-          <p class="font-mono text-xs text-muted">LAT -6.91 · LON 107.61</p>
+          <p class="font-mono text-xs text-muted">BANDUNG, ID</p>
           <p class="font-mono text-xs text-accent" data-testid="local-clock">{{ clock }} WIB</p>
         </div>
       </div>
 
+      <!-- Value proposition leads — this is a business profile, not a résumé. -->
       <h1
         data-boot="name"
-        data-testid="hero-name"
-        class="glitch glow mt-8 font-semibold tracking-tight uppercase"
-        :data-text="profile.name"
-        style="font-size: clamp(3rem, 11vw, 9rem); line-height: 0.9; letter-spacing: -0.03em"
+        data-testid="hero-valueprop"
+        class="glow mt-8 max-w-4xl font-semibold tracking-tight text-fg"
+        style="font-size: clamp(2.5rem, 7vw, 5.5rem); line-height: 1.03; letter-spacing: -0.03em"
       >
-        {{ profile.name }}
+        {{ profile.valueProp }}
       </h1>
 
+      <!-- Name credit + availability (one boot group). -->
       <p
-        v-if="profile.availableForWork"
         data-boot="badge"
-        data-testid="availability-badge"
-        class="mt-6 inline-flex items-center gap-2 font-mono text-xs tracking-wide text-muted uppercase"
+        class="mt-6 flex flex-wrap items-center gap-x-3 gap-y-2 font-mono text-sm"
       >
-        <span class="relative flex size-2">
-          <span class="absolute inline-flex size-full animate-ping rounded-full bg-accent3 opacity-70" />
-          <span class="relative inline-flex size-2 rounded-full bg-accent3" />
+        <span class="font-medium text-fg" data-testid="hero-name">{{ profile.name }}</span>
+        <span class="text-accent" aria-hidden="true">/</span>
+        <span class="text-muted">{{ profile.title }}</span>
+        <span
+          v-if="profile.availableForWork"
+          data-testid="availability-badge"
+          class="inline-flex items-center gap-2 rounded-full border border-accent3/40 px-3 py-1 text-xs tracking-wide text-fg/90 uppercase"
+        >
+          <span class="relative flex size-2">
+            <span class="absolute inline-flex size-full animate-ping rounded-full bg-accent3 opacity-70" />
+            <span class="relative inline-flex size-2 rounded-full bg-accent3" />
+          </span>
+          Available for work
         </span>
-        Open to senior frontend roles
       </p>
 
-      <p data-boot="tagline" data-testid="hero-tagline" class="mt-5 max-w-xl text-lg text-muted sm:text-xl">
-        {{ profile.tagline }}
+      <p data-boot="tagline" data-testid="hero-tagline" class="mt-6 max-w-xl text-lg text-muted sm:text-xl">
+        {{ profile.valuePropSub }}
       </p>
 
       <div data-boot="cta" class="mt-8 flex flex-wrap items-center gap-3">
@@ -159,7 +167,7 @@ onUnmounted(() => {
           target="_blank"
           rel="noopener noreferrer"
           data-testid="hero-cta-call"
-          data-cursor
+          data-cursor="book a call"
           class="inline-flex items-center gap-2 rounded-md bg-accent px-6 py-3 text-sm font-semibold text-[#06070d] transition-colors hover:bg-accent-soft"
         >
           <AppIcon name="calendar" :size="18" />
@@ -167,10 +175,19 @@ onUnmounted(() => {
         </a>
         <a
           v-magnetic="0.3"
+          href="#services"
+          data-testid="hero-cta-services"
+          data-cursor
+          class="inline-flex items-center gap-2 rounded-md border border-line px-6 py-3 text-sm font-semibold text-fg transition-colors hover:border-accent"
+        >
+          See what I do
+          <AppIcon name="arrow-right" :size="16" />
+        </a>
+        <a
           href="#work"
           data-testid="hero-cta-work"
           data-cursor
-          class="inline-flex items-center gap-2 rounded-md border border-line px-6 py-3 text-sm font-semibold text-fg transition-colors hover:border-accent"
+          class="inline-flex items-center gap-2 px-2 py-3 text-sm font-medium text-muted transition-colors hover:text-accent"
         >
           View work
           <AppIcon name="arrow-down" :size="16" />

--- a/src/components/sections/ProcessSection.vue
+++ b/src/components/sections/ProcessSection.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import SectionHeading from '../ui/SectionHeading.vue'
+import ParallaxText from '../fx/ParallaxText.vue'
+import { usePortfolio } from '@/composables/usePortfolio'
+
+const { process } = usePortfolio()
+const pad = (n: number) => String(n).padStart(2, '0')
+</script>
+
+<template>
+  <section id="process" data-testid="process" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
+    <ParallaxText text="PROCESS" position="-top-12 right-0" :amount="0.6" />
+    <SectionHeading
+      eyebrow="03 / How I work"
+      title="A clear path, written down"
+      subtitle="No mystery, no lock-in. Every engagement follows the same simple arc so the team always knows where things stand."
+    />
+
+    <ol class="grid gap-4 sm:gap-5 md:grid-cols-2 lg:grid-cols-4" data-testid="process-list">
+      <li
+        v-for="(step, index) in process"
+        :key="step.id"
+        v-reveal
+        :data-testid="`process-${step.id}`"
+        class="relative flex flex-col rounded-2xl border border-line bg-surface/40 p-6"
+      >
+        <div class="flex items-center gap-3">
+          <span class="font-mono text-2xl font-semibold text-accent">{{ pad(index + 1) }}</span>
+          <span
+            v-if="index < process.length - 1"
+            class="h-px flex-1 bg-line"
+            aria-hidden="true"
+          />
+        </div>
+        <h3 class="mt-4 text-lg font-semibold text-fg">{{ step.title }}</h3>
+        <p class="mt-2 text-sm leading-relaxed text-muted">{{ step.description }}</p>
+      </li>
+    </ol>
+  </section>
+</template>

--- a/src/components/sections/ProjectsSection.vue
+++ b/src/components/sections/ProjectsSection.vue
@@ -61,9 +61,9 @@ onUnmounted(() => mm?.revert())
   <section id="work" ref="root" data-testid="work" class="relative py-24">
     <div class="mx-auto max-w-6xl px-4 sm:px-8">
       <SectionHeading
-        eyebrow="04 / Selected Work"
-        title="Projects & case studies"
-        subtitle="Scroll — the deck slides sideways through each project."
+        eyebrow="02 / Selected work"
+        title="Case studies"
+        subtitle="A few projects that show the work — scroll, the deck slides sideways through each one."
       />
     </div>
 

--- a/src/components/sections/ServicesSection.vue
+++ b/src/components/sections/ServicesSection.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import SectionHeading from '../ui/SectionHeading.vue'
+import AppIcon from '../ui/AppIcon.vue'
+import ParallaxText from '../fx/ParallaxText.vue'
+import { usePortfolio } from '@/composables/usePortfolio'
+import type { IconName } from '../ui/icons'
+
+const { services } = usePortfolio()
+const pad = (n: number) => String(n).padStart(2, '0')
+</script>
+
+<template>
+  <section id="services" data-testid="services" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
+    <ParallaxText text="SERVICES" position="-top-12 -left-4" :amount="0.55" />
+    <SectionHeading
+      eyebrow="01 / What I do"
+      title="How I help teams ship"
+      subtitle="Four ways I plug into a product team — from the first architecture decision to a team that can keep moving without me."
+    />
+
+    <div class="grid gap-4 sm:gap-5 md:grid-cols-2" data-testid="services-grid">
+      <article
+        v-for="(service, index) in services"
+        :key="service.id"
+        v-reveal
+        :data-testid="`service-${service.id}`"
+        data-cursor
+        class="service-card group relative flex flex-col overflow-hidden rounded-2xl border border-line bg-surface/40 p-7 transition-colors hover:border-accent/50 sm:p-8"
+      >
+        <span
+          class="pointer-events-none absolute top-5 right-6 font-mono text-xs text-muted/60 select-none"
+          aria-hidden="true"
+          >{{ pad(index + 1) }}</span
+        >
+        <span
+          class="grid size-12 place-items-center rounded-xl border border-line text-accent transition-colors group-hover:border-accent/60"
+        >
+          <AppIcon :name="(service.icon as IconName)" :size="22" />
+        </span>
+
+        <h3 class="mt-5 text-xl font-semibold text-fg">{{ service.title }}</h3>
+        <p class="mt-2 text-sm leading-relaxed text-muted">{{ service.summary }}</p>
+
+        <ul class="mt-5 space-y-2 border-t border-line pt-4">
+          <li
+            v-for="capability in service.capabilities"
+            :key="capability"
+            class="flex items-start gap-2.5 text-sm text-fg/85"
+          >
+            <AppIcon name="check" :size="15" class="mt-0.5 shrink-0 text-accent" />
+            <span>{{ capability }}</span>
+          </li>
+        </ul>
+      </article>
+    </div>
+  </section>
+</template>

--- a/src/components/sections/SkillsSection.vue
+++ b/src/components/sections/SkillsSection.vue
@@ -10,7 +10,7 @@ const { skillGroups, education } = usePortfolio()
   <section id="skills" data-testid="skills" class="relative mx-auto max-w-6xl px-4 py-24 sm:px-8">
     <ParallaxText text="STACK" position="-top-10 -left-4" :amount="0.55" />
     <SectionHeading
-      eyebrow="05 / Skills"
+      eyebrow="06 / Capabilities"
       title="Tools of the trade"
       subtitle="Frontend-deep, full-stack-aware. Years reflect hands-on experience."
     />

--- a/src/components/sections/TrustedBy.vue
+++ b/src/components/sections/TrustedBy.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { usePortfolio } from '@/composables/usePortfolio'
+
+const { clients } = usePortfolio()
+</script>
+
+<template>
+  <section
+    data-testid="trusted-by"
+    aria-label="Companies I've worked with"
+    class="border-y border-line bg-surface/30"
+  >
+    <div class="mx-auto max-w-6xl px-4 py-10 sm:px-8" v-reveal>
+      <p class="kicker text-center sm:text-left">Trusted by teams at</p>
+      <ul
+        class="mt-5 flex flex-wrap items-center justify-center gap-x-8 gap-y-4 sm:justify-start sm:gap-x-12"
+        data-testid="client-list"
+      >
+        <li v-for="client in clients" :key="client.name">
+          <component
+            :is="client.url ? 'a' : 'span'"
+            v-bind="
+              client.url
+                ? { href: client.url, target: '_blank', rel: 'noopener noreferrer' }
+                : {}
+            "
+            :data-cursor="client.url ? '' : undefined"
+            class="text-lg font-semibold tracking-tight text-muted/70 transition-colors hover:text-fg sm:text-xl"
+          >
+            {{ client.name }}
+          </component>
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>

--- a/src/components/ui/icons.ts
+++ b/src/components/ui/icons.ts
@@ -14,6 +14,11 @@ export type IconName =
   | 'sparkles'
   | 'copy'
   | 'check'
+  | 'layers'
+  | 'grid'
+  | 'git-branch'
+  | 'users'
+  | 'arrow-right'
 
 export const ICON_PATHS: Record<IconName, string> = {
   github:
@@ -37,4 +42,12 @@ export const ICON_PATHS: Record<IconName, string> = {
     '<path d="M9.94 14.06A2 2 0 0 0 8.5 12.6l-5.1-1.3 5.1-1.3A2 2 0 0 0 9.94 8.5l1.3-5.1 1.3 5.1a2 2 0 0 0 1.46 1.5l5.1 1.3-5.1 1.3a2 2 0 0 0-1.46 1.46l-1.3 5.1z"/>',
   copy: '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2"/>',
   check: '<path d="M20 6 9 17l-5-5"/>',
+  layers:
+    '<path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83Z"/><path d="m6.08 9.5-3.49 1.59a1 1 0 0 0 0 1.83l8.59 3.9a2 2 0 0 0 1.65 0l8.58-3.9a1 1 0 0 0 0-1.83L17.92 9.5"/><path d="m6.08 14.5-3.49 1.59a1 1 0 0 0 0 1.83l8.59 3.9a2 2 0 0 0 1.65 0l8.58-3.9a1 1 0 0 0 0-1.83l-3.49-1.59"/>',
+  grid: '<rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/>',
+  'git-branch':
+    '<line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/>',
+  users:
+    '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>',
+  'arrow-right': '<path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>',
 }

--- a/src/composables/usePortfolio.ts
+++ b/src/composables/usePortfolio.ts
@@ -1,4 +1,13 @@
-import { profile, experiences, projects, skillGroups, education } from '@/data/cv'
+import {
+  profile,
+  experiences,
+  projects,
+  skillGroups,
+  education,
+  services,
+  process,
+  clients,
+} from '@/data/cv'
 import {
   buildExperienceTimeline,
   getFeaturedProjects,
@@ -17,5 +26,8 @@ export function usePortfolio() {
     projects: getFeaturedProjects(projects),
     skillGroups,
     education: getEducationHistory(education),
+    services,
+    process,
+    clients,
   }
 }

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -1,5 +1,14 @@
 import { DateRange } from '@/utils/dateRange'
-import type { Profile, Experience, Project, SkillGroup, Education } from '@/types/portfolio'
+import type {
+  Profile,
+  Experience,
+  Project,
+  SkillGroup,
+  Education,
+  Service,
+  ProcessStep,
+  Client,
+} from '@/types/portfolio'
 
 /**
  * Source of truth for the portfolio content, transcribed from Hendri's CV.
@@ -13,6 +22,9 @@ export const profile: Profile = {
   company: 'Mekari',
   companyUrl: 'https://www.mekari.com',
   location: 'Bandung, Indonesia',
+  valueProp: 'Frontend architecture that scales with your team.',
+  valuePropSub:
+    'I help product teams ship maintainable web apps — micro-frontends, design systems, and the engineering culture to keep them fast as they grow.',
   tagline: 'I build scalable web apps, micro-frontends, and design systems.',
   summary:
     'Senior Frontend Engineer based in Bandung with around 10 years of experience building and scaling web applications. At Mekari I lead frontend architecture and large-scale migrations — micro-frontends with Module Federation, shared design systems (Mekari Pixel), and engineering quality. I care about maintainable architecture, design systems, testing, and growing the engineers around me. With a background in Industrial Engineering, I am especially drawn to digitalizing industry and ERP.',
@@ -295,6 +307,95 @@ export const projects: Project[] = [
     featured: true,
     order: 4,
   },
+]
+
+export const services: Service[] = [
+  {
+    id: 'architecture',
+    icon: 'layers',
+    title: 'Frontend Architecture',
+    summary:
+      'Designing frontends that stay fast and maintainable as teams and codebases grow — from RFC to rollout.',
+    capabilities: [
+      'Architecture RFCs & migration strategy',
+      'Module Federation & monorepo setup',
+      'Performance & build pipelines',
+    ],
+  },
+  {
+    id: 'design-systems',
+    icon: 'grid',
+    title: 'Design Systems',
+    summary:
+      'Shared component libraries that keep products consistent and ship features faster across teams.',
+    capabilities: [
+      'Component libraries & tokens',
+      'Storybook documentation',
+      'CDN-distributed shared UI',
+    ],
+  },
+  {
+    id: 'micro-frontends',
+    icon: 'git-branch',
+    title: 'Micro-Frontends & Migration',
+    summary:
+      'Decoupling large applications into independently deployable modules — and modernising legacy code along the way.',
+    capabilities: [
+      'Module Federation rollout',
+      'Legacy-to-modern migration',
+      'Independent build & deploy',
+    ],
+  },
+  {
+    id: 'leadership',
+    icon: 'users',
+    title: 'Technical Leadership',
+    summary:
+      'Growing engineering teams through mentoring, code quality, and a culture of testing and documentation.',
+    capabilities: [
+      'Mentoring & onboarding',
+      'Testing standards (80%+ coverage)',
+      'Engineering guidelines & reviews',
+    ],
+  },
+]
+
+export const process: ProcessStep[] = [
+  {
+    id: 'discover',
+    title: 'Discover',
+    description:
+      'Understand the product, the team, and the constraints. Map what hurts today and what success looks like.',
+  },
+  {
+    id: 'architect',
+    title: 'Architect',
+    description:
+      'Propose a clear technical direction — written down as an RFC the whole team can align on before any code.',
+  },
+  {
+    id: 'build',
+    title: 'Build',
+    description:
+      'Ship incrementally with tests and documentation, keeping the product shippable at every step.',
+  },
+  {
+    id: 'enable',
+    title: 'Enable',
+    description:
+      'Hand over with guidelines, Storybook, and mentoring so the team keeps moving fast without me.',
+  },
+]
+
+/** Companies worked with — social proof for the trusted-by strip. */
+export const clients: Client[] = [
+  { name: 'Mekari', url: 'https://www.mekari.com' },
+  { name: 'Ralali.com', url: 'https://www.ralali.com' },
+  { name: 'Labtek Indie' },
+  { name: 'eBdesk Teknologi' },
+  { name: 'Terakorp' },
+  { name: 'Nutrifood' },
+  { name: '9cv9' },
 ]
 
 export const skillGroups: SkillGroup[] = [

--- a/src/style.css
+++ b/src/style.css
@@ -154,7 +154,7 @@
       linear-gradient(to right, var(--color-line) 1px, transparent 1px),
       linear-gradient(to bottom, var(--color-line) 1px, transparent 1px);
     background-size: clamp(48px, 6vw, 96px) clamp(48px, 6vw, 96px);
-    opacity: 0.35;
+    opacity: 0.28;
     mask-image: radial-gradient(ellipse 120% 80% at 50% 0%, #000 25%, transparent 75%);
   }
   .fx-scanlines {
@@ -162,7 +162,7 @@
     inset: 0;
     z-index: 1;
     pointer-events: none;
-    opacity: 0.5;
+    opacity: 0.22;
     background: repeating-linear-gradient(
       to bottom,
       transparent 0 2px,

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -30,6 +30,10 @@ export interface Profile {
   readonly company: string
   readonly companyUrl: string
   readonly location: string
+  /** Short, client-facing value proposition — the dominant hero headline. */
+  readonly valueProp: string
+  /** Supporting sentence under the value proposition. */
+  readonly valuePropSub: string
   readonly tagline: string
   readonly summary: string
   readonly availableForWork: boolean
@@ -37,6 +41,32 @@ export interface Profile {
   readonly socials: readonly SocialLink[]
   readonly languages: readonly Language[]
   readonly softSkills: readonly string[]
+}
+
+// --- Services & process (business-profile framing) -------------------------
+
+/**
+ * A capability offered to clients/teams. `icon` keys into the shared icon set.
+ */
+export interface Service {
+  readonly id: string
+  readonly icon: string
+  readonly title: string
+  readonly summary: string
+  readonly capabilities: readonly string[]
+}
+
+/** One step in the "how I work" engagement flow. */
+export interface ProcessStep {
+  readonly id: string
+  readonly title: string
+  readonly description: string
+}
+
+/** A company worked with, used for the social-proof / trusted-by strip. */
+export interface Client {
+  readonly name: string
+  readonly url?: string
 }
 
 // --- Experience ------------------------------------------------------------

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -13,9 +13,27 @@ test('has the correct document title and hero identity', async ({ page }) => {
 })
 
 test('renders every primary section', async ({ page }) => {
-  for (const id of ['hero', 'about', 'experience', 'work', 'skills', 'contact']) {
+  for (const id of [
+    'hero',
+    'trusted-by',
+    'services',
+    'work',
+    'process',
+    'experience',
+    'about',
+    'skills',
+    'contact',
+  ]) {
     await expect(page.getByTestId(id)).toBeAttached()
   }
+})
+
+test('presents the business-profile value proposition and services', async ({ page }) => {
+  await expect(page.getByTestId('hero-valueprop')).toContainText('scales')
+  await expect(page.getByTestId('services-grid').locator('> article')).toHaveCount(4)
+  await expect(page.getByTestId('service-architecture')).toContainText('Architecture')
+  await expect(page.getByTestId('process-list').locator('> li')).toHaveCount(4)
+  await expect(page.getByTestId('client-list')).toContainText('Mekari')
 })
 
 test('shows the four hero highlight stats', async ({ page }) => {

--- a/tests/e2e/interactions.spec.ts
+++ b/tests/e2e/interactions.spec.ts
@@ -22,8 +22,8 @@ test('copy-email button flips to a confirmed state', async ({ page, context }) =
 })
 
 test('primary nav reflects the active section via aria-current', async ({ page }) => {
-  await page.locator('#about').scrollIntoViewIfNeeded()
-  await expect(page.getByTestId('nav-about')).toHaveAttribute('aria-current', 'true')
+  await page.locator('#services').scrollIntoViewIfNeeded()
+  await expect(page.getByTestId('nav-services')).toHaveAttribute('aria-current', 'true')
 
   await page.locator('#contact').scrollIntoViewIfNeeded()
   await expect(page.getByTestId('nav-contact')).toHaveAttribute('aria-current', 'true')

--- a/tests/unit/data.spec.ts
+++ b/tests/unit/data.spec.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { profile, experiences, projects, skillGroups, education } from '@/data/cv'
+import {
+  profile,
+  experiences,
+  projects,
+  skillGroups,
+  education,
+  services,
+  process,
+  clients,
+} from '@/data/cv'
 
 /** Collect human-readable strings, skipping date value objects. */
 function collectText(value: unknown, acc: string[] = []): string[] {
@@ -37,9 +46,30 @@ describe('cv data', () => {
     expect(projects.every((p) => p.order > 0)).toBe(true)
   })
 
+  it('frames the business profile with a value proposition and services', () => {
+    expect(profile.valueProp.length).toBeGreaterThan(0)
+    expect(profile.valuePropSub).toContain('micro-frontends')
+    expect(services.length).toBeGreaterThanOrEqual(4)
+    expect(services.every((s) => s.capabilities.length > 0)).toBe(true)
+  })
+
+  it('describes a clear engagement process and lists clients', () => {
+    expect(process.length).toBeGreaterThanOrEqual(3)
+    expect(clients.some((c) => c.name === 'Mekari')).toBe(true)
+  })
+
   // --- Privacy guardrail: the public site must contain NO PII ---
   it('contains no personally identifiable contact data (phone / street address)', () => {
-    const text = collectText({ profile, experiences, projects, skillGroups, education }).join(' \n ')
+    const text = collectText({
+      profile,
+      experiences,
+      projects,
+      skillGroups,
+      education,
+      services,
+      process,
+      clients,
+    }).join(' \n ')
     expect(text).not.toMatch(/\+?\d[\d\s().-]{7,}\d/)
     expect(text).not.toContain('+62')
     expect(text).not.toMatch(/\bJl\.?\b/i)


### PR DESCRIPTION
Evolves the site from a personal CV page into an **intuitive business / company profile** — positioned as "Hendri Faisal Hidayat — Frontend Engineering & Consulting." It now answers a visitor's real questions (what can you do for me, why you, how do we start) instead of reading like a résumé.

## Structure (new information architecture)
1. **Hero** — leads with a **value proposition** ("Frontend architecture that scales with your team") + one primary CTA; name/title demoted to a credit line. Telemetry simplified (dropped meaningless coordinates).
2. **Trusted by** — social-proof strip of real companies worked with.
3. **Services** *(new)* — bento grid of four capabilities: Frontend Architecture, Design Systems, Micro-Frontends & Migration, Technical Leadership — each with concrete deliverables.
4. **Work** — projects reframed as **Case studies**.
5. **Process** *(new)* — a clear four-step engagement flow: Discover → Architect → Build → Enable.
6. **Experience / About / Capabilities** — the supporting track record.
7. **Contact** — reframed as **"Let's work together."**

Nav becomes **Services / Work / Process / Experience / Contact** with active-section tracking; section eyebrows renumbered for the new flow.

## More intuitive, calmer theme
Dialed back the grid and scanline intensity so content reads first — premium rather than noisy — while keeping the distinctive accent and signature motion.

## Data & types
All content stays in one source (`cv.ts`), still **no PII**. Adds `Service`, `ProcessStep`, `Client` types and `valueProp`/`valuePropSub` profile fields, surfaced through `usePortfolio`.

## Tests
Extended unit + E2E for the new sections (services grid, process steps, trusted-by) and widened the PII scan to the new data. **38 tests green (21 unit + 17 E2E)**; type-check and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLznrSzLc4vuZE3bFE29wT)_